### PR TITLE
Add several updates for bitrot and QA improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
           - '1.0' # oldest supported release
           - '1.6' # LTS
           - '1' # stable release
-          - 'nightly'
+#          - 'nightly' nightly is broken if JET appears in [extras] in Project.toml (AFAICT)
         os:
           - ubuntu-latest
           - macOS-latest
@@ -38,6 +38,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,4 +1,3 @@
-
 name: CompatHelper
 on:
   schedule:
@@ -16,7 +15,7 @@ jobs:
         run: which julia
         continue-on-error: true
       - name: Install Julia, but only if it is not already available in the PATH
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: '1'
           arch: ${{ runner.arch }}

--- a/Project.toml
+++ b/Project.toml
@@ -9,14 +9,16 @@ version = "0.4.7"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 
 [compat]
+Aqua = ">= 0.8"
 IrrationalConstants = "0.2.1"
 julia = "1"
+JET = ">= 0.0"
+Test = ">= 0.0"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
 
 [targets]
 test = ["Test", "Aqua", "JET"]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 ### Lambert W function and associated omega constant
 
 [![Build Status](https://github.com/JuliaMath/LambertW.jl/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/JuliaMath/LambertW.jl/actions/workflows/CI.yml?query=branch%3Amaster)
-[![codecov.io](http://codecov.io/github/JuliaMath/LambertW.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaMath/LambertW.jl?branch=master)
+[![Codecov](https://codecov.io/gh/JuliaMath/LambertW.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaMath/LambertW.jl)
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
-[![JET QA](https://img.shields.io/badge/JET.jl-%E2%9C%88%EF%B8%8F-%23aa4444)](https://github.com/aviatesk/JET.jl)
+[![](https://img.shields.io/badge/%F0%9F%9B%A9%EF%B8%8F_tested_with-JET.jl-233f9a)](https://github.com/aviatesk/JET.jl)
 
 ### lambertw
 

--- a/test/aqua_test.jl
+++ b/test/aqua_test.jl
@@ -24,8 +24,8 @@ end
     Aqua.test_ambiguities([LambertW, Core, Base])
 end
 
-@testset "aqua piracy" begin
-    Aqua.test_piracy(LambertW)
+@testset "aqua piracies" begin
+    Aqua.test_piracies(LambertW)
 end
 
 @testset "aqua project extras" begin

--- a/test/jet_test.jl
+++ b/test/jet_test.jl
@@ -8,7 +8,9 @@ const package_to_analyze = LambertW
 ## the report message. The second is the file it occurs in.
 ## Not very precise, but ok for now.
 const SKIP_MATCHES = [
-    #  ("type Nothing has no field den", "parameters.jl"),
+    # JET 0.9.9 has a problem with: log(z::Complex) (Oct 1, 2024)
+    # So we skip it.
+    ("invalid builtin function call", "LambertW.jl"),
 ]
 
 ## Skip reports for which return true


### PR DESCRIPTION
Updates for bitrot, add many tests, QA, and CI improvements

* Try to fix badge links in README
* Update CompatHelper.yml
* Update Aqua test for newer Aqua API
* Fix Aqua complaints in Project.toml
* Restrict some input types to `Integer`
  These are always integers anyway
* Fix JET complaint
  Seems to have a problem with `log(::Complex)` in general. Looks
  like a bug, if so. We don't really fix it, but rather skip it.
* Don't test nightly on CI because it's broke with JET
* Remove non-API function for input `z == MathConstant.e`
  The removed function has an underscore prefix and is not called at all by the
  API function `lambertw`.
  This non-API function returns 1::Int, which makes no sense. If you convert `z` to `Float64`,
  then `1.0::Float64` is returned, which is just as much exactly one as `1::Int`.
  The API function intercepts the input ::MathConstant.e and converts it to float
* Improve doc strings
  lambertw was is outdated
  Function for branchpoint is better documented.
* Remove special case for argument ::AbstractIrrational
  I don't see that this code path was called by the API in any case.
  But curiously, codecov showed that this line was in fact covered by the test suite.
  The test suite in fact still passes, as expected, with this line removed.
* Remove another obsolete code path for special inputs
* Integers and Rationals are converted to floats at the API entry point.
  The removed non-API functions would add nothing if they were called. In any case, they are not.
* Part of the code path for `abs(z::Complex) <= one_t/convert(T, MathConstants.e)` was not tested before.
  This commit adds a test
* Add tests for uncovered code paths
* Some paths for complex arguments were not tested. This adds tests
* A redundant logic test was removed from code in one of these paths.
* Test inverse functions
  I used `finv(lambertw)`, but it was not tested. I tried promoting the
  idea, but didn't push hard and got no comments. There is now a package
  implementing this idea.
  In any case, this adds a test for the existing, unexported, function.
* Remove unnecessary type parameter in signature
* Simplify function signature
  I may have argued that the complicated one was slightly more performant.
  If it is, it is not significant.
* Remove unused loop variable
* Add tests for complex args to hit paths in branch point expansion
* Remove unneccesary use of `local`
* Remove another unused, and in any case, unneccesary code path
* Test string(Omega())
* Update codecov action
* Remove commented out cruft
* Rename unused loop var to underscore