### PR TITLE
Remove warning from root finding

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ also called the omega function or product logarithm.
 ```julia
 lambertw(z,k)   # Lambert W function for argument z and branch index k
 lambertw(z)     # the same as lambertw(z,0)
+lambertw_check_convergence(z, k=0) # The same as above but throw an error if the computation failed to converge
 ```
 
 `z` may be Complex or Real. `k` must be an integer. For Real
@@ -34,6 +35,11 @@ julia> lambertw(1.0)
 julia> lambertw(-pi/2 + 0im)  / pi
 4.6681174759251105e-18 + 0.5im
 ```
+
+#### Note on `lambertw_check_convergence`
+
+You can use this for extra safety. But I have been unable to find any input for which the root finding fails to
+converge quickly.
 
 ### lambertwbp(x,k=0)
 

--- a/src/LambertW.jl
+++ b/src/LambertW.jl
@@ -52,10 +52,11 @@ If `z` is real, `k` must be either `0` or `-1`. For `Real` `z`, the domain of th
 `k = -1` is `[-1/e, 0]` and the domain of the branch `k = 0` is `[-1/e, Inf]`. For
 `Complex` `z`, and all `k`, the domain is the complex plane.
 
-The result is computed via a root-finding loop. The loop exits early, without warning, if
-the number of iterations exceeds `maxits`. This will probably never happen However, if you
-want to be more careful, call `lambertw_check_convergence` instead.  The latter function
-returns the result if `maxits` was not reached, and otherwise throws an error.
+The result is computed via a root-finding loop. If the number of iterations exceeds
+`maxits`, then the loop exits early, returning a result without warning about the failure
+to converge.  This will probably never happen. However, if you want to be more careful,
+call `lambertw_check_convergence` instead.  The latter function returns the result if
+`maxits` was not reached, and otherwise throws an error.
 
 ```jldoctest
 julia> lambertw(-1/MathConstants.e, -1)

--- a/test/lambertw_test.jl
+++ b/test/lambertw_test.jl
@@ -187,3 +187,7 @@ end
 @testset "show" begin
     @test string(LambertW.Omega()) == "ω"
 end
+
+@testset "lambertw_check_convergence" begin
+    @test lambertw_check_convergence(1.0) == lambertw(1.0)
+end


### PR DESCRIPTION
Return convergence status. Call one of two functions to error
on bad status or else ignore it.