### PR TITLE
Change API regarding convergence information

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ also called the omega function or product logarithm.
 ```julia
 lambertw(z,k)   # Lambert W function for argument z and branch index k
 lambertw(z)     # the same as lambertw(z,0)
-lambertw_check_convergence(z, k=0) # The same as above but throw an error if the computation failed to converge
+lambertw(z; info=true) # Return a 3-tuple that includes convergence information.
 ```
 
 `z` may be Complex or Real. `k` must be an integer. For Real
@@ -36,7 +36,7 @@ julia> lambertw(-pi/2 + 0im)  / pi
 4.6681174759251105e-18 + 0.5im
 ```
 
-#### Note on `lambertw_check_convergence`
+#### Note on `info=true`
 
 You can use this for extra safety. But I have been unable to find any input for which the root finding fails to
 converge quickly.

--- a/test/lambertw_test.jl
+++ b/test/lambertw_test.jl
@@ -188,6 +188,15 @@ end
     @test string(LambertW.Omega()) == "ω"
 end
 
-@testset "lambertw_check_convergence" begin
-    @test lambertw_check_convergence(1.0) == lambertw(1.0)
+@testset "lambertw info" begin
+    result = lambertw(1.0; info=true)
+    @test result[1] == lambertw(1.0)
+    @test result[2]
+    @test result[3] > 1 && result[3] < 10
+
+    for z in (10., complex(10), lambertwbranchpoint)
+        res = lambertw(1.0; info=true)
+        @test res[2]
+        @test length(res) == 3
+    end
 end


### PR DESCRIPTION
There is now a single function `lambertw` for computing the Lambert W function. It takes a keyword argument, `info`. If `info` is false, the default, then only the result of computation is returned. If it is `true` then a triple giving the result and info on convergence is returned.

In neither case is a warning or error explicitly raised.
